### PR TITLE
Fix error in instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var options = {
   cssDir: "assets/css",
   fullException: false
 }
-var outputTree = compileSass(inputTrees, options);
+var outputTree = new compileSass(inputTrees, options);
 ```
 
 * **`inputTrees`**: An array of trees that act as the include paths for


### PR DESCRIPTION
There was a missing `new` statement in the usage instructions. 