### PR TITLE
Update broccoli-caching-writing, fixing bugs in process

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -159,7 +159,7 @@ function forbidNodeSassOption(options, property) {
 //   };
 var BroccoliSassCompiler = CachingWriter.extend({
   init: function(inputTrees, options) {
-    this._super.init(inputTrees);
+    this._super(inputTrees);
     this.options = copyObject(options || {});
     this.events = new EventEmitter();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var Eyeglass = require('eyeglass');
 
 var EyeglassCompiler = BroccoliSassCompiler.extend({
   init: function(inputTrees, options) {
-    this._super.init(inputTrees, options);
+    this._super(inputTrees, options);
     this.events.on("compiling", this.handleNewFile.bind(this));
   },
 
@@ -14,7 +14,7 @@ var EyeglassCompiler = BroccoliSassCompiler.extend({
 
   // Ugh. This method needs to be decomposed into smaller parts.
   updateCache: function(srcPaths, destDir) {
-    return this._super.updateCache(srcPaths, destDir);
+    return this._super(srcPaths, destDir);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -17,17 +17,17 @@
     "eyeglass"
   ],
   "dependencies": {
-    "broccoli-caching-writer": "^0.5.0",
+    "broccoli-caching-writer": "^1.1.0",
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
     "eyeglass": "^0.1.1",
     "glob": "^5.0.3",
-    "mkdirp": "^0.3.5",
+    "mkdirp": "^0.5.1",
     "node-sass": "^3.0.0-beta.5",
-    "rsvp": "^3.0.18"
+    "rsvp": "^3.0.21"
   },
   "devDependencies": {
-    "broccoli": "^0.15.3",
+    "broccoli": "^0.16.5",
     "broccoli-cli": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-release": "^0.12.0"


### PR DESCRIPTION
This PR addresses issue #14.

I didn’t add a test, *but* I’m happy to make a PR out of https://github.com/alanhogan/broccoli-eyeglass/tree/example-called-multiple-times/examples/example-4 which would add a previously failing brocfile as an example under `examples`. (See also: #11.) Or, if you’d rather, I can take a stab at making a proper test in whichever format you’d like.

Good news: The bug seems to have been in `broccoli-caching-writer`, so all it took was updating the `package.json` and changing a few `_super` calls for compatibility with b-c-w 1.x.
