### PR TITLE
Make trivial changes to make JSHint happy

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -40,16 +40,18 @@ function renderSassSync(options) {
 
 // Simple copy for options hashes.
 function copyObject(obj) {
+  var newObj, key;
+
   if (typeof obj !== "object") return obj;
   if (obj.forEach) {
-    var newObj = [];
+    newObj = [];
     obj.forEach(function(o) {
       newObj.push(copyObject(o));
     });
     return newObj;
   } else {
-    var newObj = {};
-    for(var key in obj) {
+    newObj = {};
+    for(key in obj) {
       if(obj.hasOwnProperty(key)) {
         newObj[key] = copyObject(obj[key]);
       }
@@ -67,7 +69,7 @@ function moveOption(source, destination, property) {
   } else {
     if (source.hasOwnProperty(property)) {
       destination[property] = source[property];
-      delete source[property]
+      delete source[property];
     }
     return destination[property];
   }
@@ -79,7 +81,7 @@ function removePathPrefix(prefix, fileNames) {
   }
   var newFileNames = [];
   for (var i = 0; i < fileNames.length; i++) {
-    if (fileNames[i].indexOf(prefix) == 0) {
+    if (fileNames[i].indexOf(prefix) === 0) {
       newFileNames[i] = fileNames[i].substring(prefix.length);
     } else {
       newFileNames[i] = fileNames[i];
@@ -94,7 +96,7 @@ function removePathPrefix(prefix, fileNames) {
 //     sass file. It must be called synchonously. You can change the output
 //     filename and options passed to it.
 function defaultOptionsGenerator(sassFile, cssFile, options, cb) {
-  cb(cssFile, options)
+  cb(cssFile, options);
 }
 
 // Support for older versions of node.
@@ -170,7 +172,7 @@ var BroccoliSassCompiler = CachingWriter.extend({
     if (!this.cssDir) throw new Error('Expected cssDir option.');
     if (!this.optionsGenerator) this.optionsGenerator = defaultOptionsGenerator;
     if (!this.sourceFiles) {
-      this.sourceFiles = []
+      this.sourceFiles = [];
       if (this.discover === false) {
         throw new Error("sourceFiles are required when discovery is disabled.");
       } else {
@@ -190,7 +192,7 @@ var BroccoliSassCompiler = CachingWriter.extend({
 
   logCompilationSuccess: function(details, result) {
     var timeInSeconds = result.stats.duration / 1000.0;
-    if (timeInSeconds == 0) timeInSeconds = "0.001" // nothing takes zero seconds.
+    if (timeInSeconds === 0) timeInSeconds = "0.001"; // nothing takes zero seconds.
     var action = colors.inverse.green("compile (" + timeInSeconds + "s)");
     var message = details.fullSassFilename + " => " + details.cssFilename;
     console.log(action + " " + message);
@@ -269,7 +271,7 @@ var BroccoliSassCompiler = CachingWriter.extend({
 
   handleSuccess: function(details, result) {
     mkdirp.sync(path.dirname(details.fullCssFilename));
-    fs.writeFileSync(details.fullCssFilename, result.css)
+    fs.writeFileSync(details.fullCssFilename, result.css);
     return this.events.emit("compiled", details, result);
   },
 
@@ -287,7 +289,7 @@ var BroccoliSassCompiler = CachingWriter.extend({
     var files = [];
     if (this.discover) {
       var pattern = path.join(srcPath, sassDir, "**", "[^_]*.scss");
-      files = glob.sync(pattern)
+      files = glob.sync(pattern);
     }
     this.sourceFiles.forEach(function(sourceFile) {
       var pattern = path.join(srcPath, sassDir, sourceFile);
@@ -308,7 +310,7 @@ var BroccoliSassCompiler = CachingWriter.extend({
 
     // TODO: limit concurrency?
     var promises = srcPaths.reduce(function (results, srcPath) {
-      return results.concat(self.compileTree(srcPath, files[srcPath], destDir))
+      return results.concat(self.compileTree(srcPath, files[srcPath], destDir));
     }, []);
 
 


### PR DESCRIPTION
Shouldn’t change anything, but this made my linter happier. A few semicolons and triple equals. Also moved a few `var` statements to the top of their functions.