### PR TITLE
Update Eyeglass requirement & usage to 0.5.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var BroccoliSassCompiler = require('./broccoli_sass_compiler');
-var Eyeglass = require('eyeglass');
+var Eyeglass = require('eyeglass').Eyeglass;
 
 var EyeglassCompiler = BroccoliSassCompiler.extend({
   init: function(inputTrees, options) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^0.5.0",
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
-    "eyeglass": "^0.1.1",
+    "eyeglass": "^0.5.0",
     "glob": "^5.0.3",
     "mkdirp": "^0.3.5",
     "node-sass": "^3.0.0-beta.5",


### PR DESCRIPTION
Just bump the Eyeglass version. This necessitates a small change to its usage as it now exports a module with two keys