### PR TITLE
Import all asset paths sent to broccoli-eyeglass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ var EyeglassCompiler = BroccoliSassCompiler.extend({
     var eyeglass = new Eyeglass(details.options, this._super.sass);
     if (this.assetDirectories) {
       for (var i = 0; i < this.assetDirectories.length; i++) {
-        eyeglass.assets.addSource(path.resolve(".", this.assetDirectories[0]), {
+        eyeglass.assets.addSource(path.resolve(".", this.assetDirectories[i]), {
           globOpts: {
             ignore: ["**/*.js", "**/*.s[ac]ss"]
           }


### PR DESCRIPTION
Fixes a bug where an array is accepted but only the first value is used.