### PR TITLE
fix inheritance bug introduced by b07c3ac20e2a4d82498dc18d06a8424d3e5…

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -159,7 +159,6 @@ function forbidNodeSassOption(options, property) {
 function BroccoliSassCompiler(inputTrees, options) {
   CachingWriter.call(this, inputTrees, options);
 
-  this.name = "BroccoliSassCompiler";
   this.sass = sass;
   this.options = copyObject(options || {});
   this.events = new EventEmitter();
@@ -193,6 +192,7 @@ function BroccoliSassCompiler(inputTrees, options) {
   }
 }
 BroccoliSassCompiler.prototype = Object.create(CachingWriter.prototype);
+BroccoliSassCompiler.prototype.constructor = BroccoliSassCompiler;
 BroccoliSassCompiler.prototype.logCompilationSuccess = function(details, result) {
   var timeInSeconds = result.stats.duration / 1000.0;
   if (timeInSeconds === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,11 +45,11 @@ function EyeglassCompiler(inputTrees, options) {
 
   // TODO: this should not be accessed before super (ES6 Aligment);
   BroccoliSassCompiler.call(this, inputTrees, options);
-  this.name = "EyeglassCompiler";
   this.events.on("compiling", this.handleNewFile.bind(this));
 }
 
 EyeglassCompiler.prototype = Object.create(BroccoliSassCompiler.prototype);
+EyeglassCompiler.prototype.constructor = EyeglassCompiler;
 EyeglassCompiler.prototype.handleNewFile = function(details) {
   if (!details.options.eyeglass) {
     details.options.eyeglass = {};


### PR DESCRIPTION
fix inheritance issue introduced by: b07c3ac20e

There was a pre-existing issue, which resulted in EyeglassCompiler logging as CoreObject, b07c3ac20e made this slightly better resulting in the name of the plugin being derived as BroccoliCachingWriter, the grandparent of EyeglassCompiler. This addressed both.

...I can't wait for us to drop old versions of node, so we can just use ES6 classes #somedayWeWillHaveNiceThings