### PR TITLE
Caching that isn't broken.

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -2,6 +2,7 @@ var path = require("path");
 var fs = require("fs");
 var mkdirp = require("mkdirp");
 var CachingWriter = require("broccoli-caching-writer");
+var MergeTrees = require("broccoli-merge-trees");
 var sass = require("node-sass");
 var glob = require("glob");
 var colors = require("colors/safe");
@@ -159,10 +160,21 @@ function forbidNodeSassOption(options, property) {
 //     options: /* The options used for this compile */
 //   };
 //
-function BroccoliSassCompiler(inputTrees, options) {
+function BroccoliSassCompiler(inputTree, options) {
+  if (Array.isArray(inputTree)) {
+    if (inputTree.length > 1) {
+      console.warn("Support for passing several trees to BroccoliSassCompiler has been removed.\n" +
+                   "We are passing the trees to broccoli-merge-trees with the overwrite option set,\n" +
+                   "but you should do this yourself if you need to compile CSS files from them\n" +
+                   "or use the node-sass includePaths option if you just need to import from them.");
+      inputTree = new MergeTrees(inputTree, {overwrite: true, annotation: "Sass Trees"});
+    } else {
+      inputTree = inputTree[0];
+    }
+  }
   options = options || {};
   options.persistentOutput = true;
-  CachingWriter.call(this, inputTrees, options);
+  CachingWriter.call(this, [inputTree], options);
 
   this.sass = sass;
   this.options = copyObject(options || {});
@@ -312,24 +324,22 @@ BroccoliSassCompiler.prototype.filesInTree = function(srcPath) {
 };
 
 BroccoliSassCompiler.prototype.build = function() {
-  // TODO: only allow one input tree
-  var inputPaths = this.inputPaths;
+  var inputPath = this.inputPaths[0];
   var outputPath = this.outputPath;
 
 
-  var entries = walkSync.entries(inputPaths[0]);
+  var entries = walkSync.entries(inputPath);
   var nextTree = new FSTree.fromEntries(entries);
   var currentTree = this.currentTree;
   this.currentTree = nextTree;
   var patches = currentTree.calculatePatch(nextTree);
 
 
-  // TODO: add inputPaths (incl sassDir for the first) to the includePaths option
   var self = this;
   var files = {};
 
   this.events.on("compiled", function(details, result) {
-    var depFiles = removePathPrefix(inputPaths[0], result.stats.includedFiles);
+    var depFiles = removePathPrefix(inputPath, result.stats.includedFiles);
     for (var i = 0; i < depFiles.length; i++) {
       self.dependencies[details.sassFilename] = self.dependencies[details.sassFilename] || new Set();
       self.dependencies[details.sassFilename].add(depFiles[i]);
@@ -337,29 +347,21 @@ BroccoliSassCompiler.prototype.build = function() {
   });
 
 
-  for (var i = 0; i < inputPaths.length; i++) {
-    // TODO: handle indented syntax files.
-    var treeFiles = removePathPrefix(inputPaths[i], this.filesInTree(inputPaths[i]));
-    treeFiles = treeFiles.filter(function(f, i) {
-      if (self.dependencies[f] === undefined) {
+  // TODO: handle indented syntax files.
+  var treeFiles = removePathPrefix(inputPath, this.filesInTree(inputPath));
+  treeFiles = treeFiles.filter(function(f, i) {
+    if (self.dependencies[f] === undefined) {
+      return true;
+    }
+    for (var p = 0; p < patches.length; p++) {
+      var entry = patches[p][2];
+      if (self.dependencies[f].has(entry.relativePath)) {
         return true;
       }
-      for (var p = 0; p < patches.length; p++) {
-        var entry = patches[p][2];
-        if (self.dependencies[f].has(entry.relativePath)) {
-          return true;
-        }
-      }
-    });
-    files[inputPaths[i]] = treeFiles;
-  }
+    }
+  });
 
-  // TODO: limit concurrency?
-  var promises = inputPaths.reduce(function (results, srcPath) {
-    return results.concat(self.compileTree(srcPath, files[srcPath], outputPath));
-  }, []);
-
-  return RSVP.all(promises);
+  return RSVP.all(self.compileTree(inputPath, treeFiles, outputPath));
 };
 
 module.exports = BroccoliSassCompiler;

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -1,7 +1,7 @@
 var path = require("path");
 var fs = require("fs");
 var mkdirp = require("mkdirp");
-var CachingWriter = require("broccoli-caching-writer");
+var BroccoliPlugin = require("broccoli-plugin");
 var MergeTrees = require("broccoli-merge-trees");
 var sass = require("node-sass");
 var glob = require("glob");
@@ -174,7 +174,7 @@ function BroccoliSassCompiler(inputTree, options) {
   }
   options = options || {};
   options.persistentOutput = true;
-  CachingWriter.call(this, [inputTree], options);
+  BroccoliPlugin.call(this, [inputTree], options);
 
   this.sass = sass;
   this.options = copyObject(options || {});
@@ -211,7 +211,7 @@ function BroccoliSassCompiler(inputTree, options) {
     this.events.on("failed", this.logCompilationFailure.bind(this));
   }
 }
-BroccoliSassCompiler.prototype = Object.create(CachingWriter.prototype);
+BroccoliSassCompiler.prototype = Object.create(BroccoliPlugin.prototype);
 BroccoliSassCompiler.prototype.constructor = BroccoliSassCompiler;
 BroccoliSassCompiler.prototype.logCompilationSuccess = function(details, result) {
   var timeInSeconds = result.stats.duration / 1000.0;
@@ -329,7 +329,13 @@ BroccoliSassCompiler.prototype.build = function() {
 
 
   var entries = walkSync.entries(inputPath);
-  var nextTree = new FSTree.fromEntries(entries);
+  if (this.options.includePaths) {
+    this.options.includePaths.forEach(function(p) {
+      entries = entries.concat(walkSync.entries(p));
+    });
+  }
+
+  var nextTree = new FSTree.fromEntries(entries, {sortAndExpand: true});
   var currentTree = this.currentTree;
   this.currentTree = nextTree;
   var patches = currentTree.calculatePatch(nextTree);
@@ -338,14 +344,13 @@ BroccoliSassCompiler.prototype.build = function() {
   var self = this;
 
   this.events.on("compiled", function(details, result) {
-    var depFiles = removePathPrefix(inputPath, result.stats.includedFiles);
+    var depFiles = result.stats.includedFiles;
     for (var i = 0; i < depFiles.length; i++) {
       self.dependencies[details.sassFilename] =
         self.dependencies[details.sassFilename] || new Set();
       self.dependencies[details.sassFilename].add(depFiles[i]);
     }
   });
-
 
   // TODO: handle indented syntax files.
   var treeFiles = removePathPrefix(inputPath, this.filesInTree(inputPath));
@@ -355,7 +360,7 @@ BroccoliSassCompiler.prototype.build = function() {
     }
     for (var p = 0; p < patches.length; p++) {
       var entry = patches[p][2];
-      if (self.dependencies[f].has(entry.relativePath)) {
+      if (self.dependencies[f].has(path.join(entry.basePath, entry.relativePath))) {
         return true;
       }
     }

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -3,6 +3,7 @@ var fs = require("fs");
 var mkdirp = require("mkdirp");
 var BroccoliPlugin = require("broccoli-plugin");
 var MergeTrees = require("broccoli-merge-trees");
+var Eyeglass = require("eyeglass");
 var sass = require("node-sass");
 var glob = require("glob");
 var colors = require("colors/safe");
@@ -333,6 +334,13 @@ BroccoliSassCompiler.prototype.build = function() {
     this.options.includePaths.forEach(function(p) {
       entries = entries.concat(walkSync.entries(p));
     });
+  }
+
+  var eyeglass = new Eyeglass(this.options);
+  var moduleKeys = Object.keys(eyeglass.modules.collection);
+  for (var m = 0; m < moduleKeys.length; m++) {
+    var moduleSassEntries = walkSync.entries(eyeglass.modules.collection[moduleKeys[m]].sassDir);
+    entries = entries.concat(moduleSassEntries);
   }
 
   var nextTree = new FSTree.fromEntries(entries, {sortAndExpand: true});

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -7,6 +7,9 @@ var glob = require("glob");
 var colors = require("colors/safe");
 var RSVP = require("rsvp");
 var EventEmitter = require("chained-emitter").EventEmitter;
+var FSTree = require("fs-tree-diff");
+var walkSync = require("walk-sync");
+
 
 function unique(array) {
   var o = {};
@@ -157,11 +160,16 @@ function forbidNodeSassOption(options, property) {
 //   };
 //
 function BroccoliSassCompiler(inputTrees, options) {
+  options = options || {};
+  options.persistentOutput = true;
   CachingWriter.call(this, inputTrees, options);
 
   this.sass = sass;
   this.options = copyObject(options || {});
   this.events = new EventEmitter();
+
+  this.currentTree = new FSTree();
+  this.dependencies = {};
 
   moveOption(this.options, this, "cssDir", "sassDir",
     "optionsGenerator", "fullException",
@@ -304,16 +312,46 @@ BroccoliSassCompiler.prototype.filesInTree = function(srcPath) {
 };
 
 BroccoliSassCompiler.prototype.build = function() {
+  // TODO: only allow one input tree
   var inputPaths = this.inputPaths;
   var outputPath = this.outputPath;
+
+
+  var entries = walkSync.entries(inputPaths[0]);
+  var nextTree = new FSTree.fromEntries(entries);
+  var currentTree = this.currentTree;
+  this.currentTree = nextTree;
+  var patches = currentTree.calculatePatch(nextTree);
+
 
   // TODO: add inputPaths (incl sassDir for the first) to the includePaths option
   var self = this;
   var files = {};
 
+  this.events.on("compiled", function(details, result) {
+    var depFiles = removePathPrefix(inputPaths[0], result.stats.includedFiles);
+    for (var i = 0; i < depFiles.length; i++) {
+      self.dependencies[details.sassFilename] = self.dependencies[details.sassFilename] || new Set();
+      self.dependencies[details.sassFilename].add(depFiles[i]);
+    }
+  });
+
+
   for (var i = 0; i < inputPaths.length; i++) {
     // TODO: handle indented syntax files.
-    files[inputPaths[i]] = removePathPrefix(inputPaths[i], this.filesInTree(inputPaths[i]));
+    var treeFiles = removePathPrefix(inputPaths[i], this.filesInTree(inputPaths[i]));
+    treeFiles = treeFiles.filter(function(f, i) {
+      if (self.dependencies[f] === undefined) {
+        return true;
+      }
+      for (var p = 0; p < patches.length; p++) {
+        var entry = patches[p][2];
+        if (self.dependencies[f].has(entry.relativePath)) {
+          return true;
+        }
+      }
+    });
+    files[inputPaths[i]] = treeFiles;
   }
 
   // TODO: limit concurrency?

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -324,10 +324,19 @@ BroccoliSassCompiler.prototype.filesInTree = function(srcPath) {
   return unique(files);
 };
 
+
+// function timeSince(time) {
+//   var delta = process.hrtime(time);
+//   var deltaNS = delta[0] * 1e9 + delta[1];
+//   return (deltaNS / 1e6).toFixed(2) + " ms";
+// }
+
 BroccoliSassCompiler.prototype.build = function() {
   var inputPath = this.inputPaths[0];
   var outputPath = this.outputPath;
 
+
+  // var startTime = process.hrtime();
 
   var entries = walkSync.entries(inputPath);
   if (this.options.includePaths) {
@@ -348,6 +357,7 @@ BroccoliSassCompiler.prototype.build = function() {
   this.currentTree = nextTree;
   var patches = currentTree.calculatePatch(nextTree);
 
+  //console.log("Building Cache State took", timeSince(startTime));
 
   var self = this;
 

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -164,9 +164,9 @@ function BroccoliSassCompiler(inputTree, options) {
   if (Array.isArray(inputTree)) {
     if (inputTree.length > 1) {
       console.warn("Support for passing several trees to BroccoliSassCompiler has been removed.\n" +
-                   "We are passing the trees to broccoli-merge-trees with the overwrite option set,\n" +
+                   "Passing the trees to broccoli-merge-trees with the overwrite option set,\n" +
                    "but you should do this yourself if you need to compile CSS files from them\n" +
-                   "or use the node-sass includePaths option if you just need to import from them.");
+                   "or use the node-sass includePaths option if you need to import from them.");
       inputTree = new MergeTrees(inputTree, {overwrite: true, annotation: "Sass Trees"});
     } else {
       inputTree = inputTree[0];
@@ -336,12 +336,12 @@ BroccoliSassCompiler.prototype.build = function() {
 
 
   var self = this;
-  var files = {};
 
   this.events.on("compiled", function(details, result) {
     var depFiles = removePathPrefix(inputPath, result.stats.includedFiles);
     for (var i = 0; i < depFiles.length; i++) {
-      self.dependencies[details.sassFilename] = self.dependencies[details.sassFilename] || new Set();
+      self.dependencies[details.sassFilename] =
+        self.dependencies[details.sassFilename] || new Set();
       self.dependencies[details.sassFilename].add(depFiles[i]);
     }
   });

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "eyeglass"
   ],
   "dependencies": {
-    "broccoli-caching-writer": "^3.0.3",
     "broccoli-merge-trees": "^1.1.4",
+    "broccoli-plugin": "^1.2.2",
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
     "eyeglass": "^1.0.0",
@@ -36,6 +36,7 @@
     "broccoli": "^0.16.5",
     "eslint": "^0.22.0",
     "eyeglass-dev-eslint": "*",
+    "fixturify": "^0.3.0",
     "grunt": "^0.4.5",
     "grunt-release": "^0.12.0",
     "gulp": "^3.9.0",
@@ -43,6 +44,7 @@
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "jshint": "^2.8.0",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "rimraf": "^2.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "broccoli-caching-writer": "^3.0.3",
+    "broccoli-merge-trees": "^1.1.4",
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
     "eyeglass": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
     "eyeglass": "^1.0.0",
+    "fs-tree-diff": "^0.5.2",
     "glob": "^5.0.3",
     "mkdirp": "^0.5.1",
     "node-sass": "^3.9.3",
-    "rsvp": "^3.0.21"
+    "rsvp": "^3.0.21",
+    "walk-sync": "^0.3.1"
   },
   "devDependencies": {
     "broccoli": "^0.16.5",
@@ -39,6 +41,7 @@
     "gulp-eslint": "1.1.1",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
-    "jshint": "^2.8.0"
+    "jshint": "^2.8.0",
+    "mocha": "^3.0.2"
   }
 }

--- a/test/fixtures/basicProject/input/styles/_unused.scss
+++ b/test/fixtures/basicProject/input/styles/_unused.scss
@@ -1,0 +1,1 @@
+// changed but still not used.

--- a/test/fixtures/basicProject/input/styles/_used.scss
+++ b/test/fixtures/basicProject/input/styles/_used.scss
@@ -1,0 +1,1 @@
+$used-variable: true;

--- a/test/test_eyeglass_plugin.js
+++ b/test/test_eyeglass_plugin.js
@@ -176,7 +176,6 @@ describe("EyeglassCompiler", function () {
       return build(builder)
         .then(function(outputDir) {
           assertEqualDirs(outputDir, fixtureOutputDir("basicProject"));
-          var mtime = fs.statSync(path.join(outputDir, "styles", "foo.css")).mtime;
           assert.equal(1, compiledFiles.length);
 
           var unusedSourceFile = path.join(sourceDir, "styles", "_unused.scss");
@@ -184,8 +183,6 @@ describe("EyeglassCompiler", function () {
           return build(builder).then(function(outputDir2) {
             assert.equal(outputDir, outputDir2);
             assert.equal(1, compiledFiles.length);
-            var mtime2 = fs.statSync(path.join(outputDir2, "styles", "foo.css")).mtime;
-            assert.deepEqual(mtime, mtime2);
           });
         });
     });
@@ -206,7 +203,6 @@ describe("EyeglassCompiler", function () {
       return build(builder)
         .then(function(outputDir) {
           assertEqualDirs(outputDir, fixtureOutputDir("basicProject"));
-          var mtime = fs.statSync(path.join(outputDir, "styles", "foo.css")).mtime;
           assert.equal(1, compiledFiles.length);
 
           var sourceFile = path.join(sourceDir, "styles", "foo.scss");
@@ -225,7 +221,6 @@ describe("EyeglassCompiler", function () {
             .then(function(outputDir2) {
               assert.equal(outputDir, outputDir2);
               var outputFile = path.join(outputDir2, "styles", "foo.css");
-              var mtime2 = fs.statSync(outputFile).mtime;
               assert.equal(newExpectedOutput, fs.readFileSync(outputFile));
               assert.equal(2, compiledFiles.length);
             })


### PR DESCRIPTION
The caching system we used to have had a number of problems:

1. changes to files outside the broccoli tree would not invalidate the cache.
2. a change in the tree would force a recompile of all sass files within the tree whether or not that sass file had a dependency on the file that changed.

This PR uses `fs-tree-diff` to do change tracking of possible dependencies for rebuilds. The changed files are then checked against the files that are known dependencies from the last compile of each sass file as reported by `node-sass`'s `result.stats.includedFiles`.

This PR is a WIP but it already handles the most important use cases so we can start testing and reviewing this strategy.