### PR TITLE
Correctly invalidate caches when an asset changes.

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -137,6 +137,12 @@ function forbidNodeSassOption(options, property) {
 // it doesn't own. It uses the node-sass async api via promises.
 // It allows several css files to be compiled from a single sass file
 // by customizing the options and output file names.
+//
+// You can emit the following events from custom functions that are invoked during compilation:
+// * compiler.events.emit("dependency", function(absolutePath) {});
+//     marks the file as a dependency for the Sass file being compiled to that future
+//     compiles will invalidate the cache if that file changes.
+//
 // You can subscribe to the following events:
 //
 //   * compiler.events.on("compiling", function(details) { });
@@ -285,11 +291,19 @@ BroccoliSassCompiler.prototype.compileCssFile = function(details) {
   var sass = this.renderer();
   var success = this.handleSuccess.bind(this, details);
   var failure = this.handleFailure.bind(this, details);
+  var self = this;
 
   return this.events.emit("compiling", details)
     .then(function() {
+      var dependencyListener = function(absolutePath) {
+        self.addDependency(details.fullSassFilename, absolutePath);
+      };
+      self.events.addListener("dependency", dependencyListener);
       return sass(details.options)
-        .then(success, failure);
+        .then(function(result) {
+          self.events.removeListener("dependency", dependencyListener);
+          success(result);
+        }, failure);
     });
 };
 
@@ -324,6 +338,19 @@ BroccoliSassCompiler.prototype.filesInTree = function(srcPath) {
   return unique(files);
 };
 
+function Entry(path) {
+  var stats = fs.statSync(path);
+  this.relativePath = path;
+  this.basePath = "/";
+  this.mode = stats.mode;
+  this.size = stats.size;
+  this.mtime = stats.mtime;
+}
+
+Entry.prototype.isDirectory = function() {
+  return false;
+};
+
 
 // function timeSince(time) {
 //   var delta = process.hrtime(time);
@@ -331,12 +358,18 @@ BroccoliSassCompiler.prototype.filesInTree = function(srcPath) {
 //   return (deltaNS / 1e6).toFixed(2) + " ms";
 // }
 
+BroccoliSassCompiler.prototype.addDependency = function(sassFilename, dependencyFilename) {
+  this.dependencies[sassFilename] =
+    this.dependencies[sassFilename] || new Set();
+  this.dependencies[sassFilename].add(dependencyFilename);
+};
+
 BroccoliSassCompiler.prototype.build = function() {
   var inputPath = this.inputPaths[0];
   var outputPath = this.outputPath;
 
 
-  // var startTime = process.hrtime();
+  //var startTime = process.hrtime();
 
   var entries = walkSync.entries(inputPath);
   if (this.options.includePaths) {
@@ -347,12 +380,28 @@ BroccoliSassCompiler.prototype.build = function() {
 
   var eyeglass = new Eyeglass(this.options);
   var moduleKeys = Object.keys(eyeglass.modules.collection);
+  var assetFiles = [];
   for (var m = 0; m < moduleKeys.length; m++) {
-    var moduleSassEntries = walkSync.entries(eyeglass.modules.collection[moduleKeys[m]].sassDir);
-    entries = entries.concat(moduleSassEntries);
+    var mod = eyeglass.modules.collection[moduleKeys[m]];
+    entries = entries.concat(walkSync.entries(mod.sassDir));
+    if (mod.assets) {
+      mod.assets.sources.forEach(function(source){
+        source.getAssets(mod.name).files.forEach(function(asset) {
+          assetFiles.push(new Entry(asset.sourcePath));
+        });
+      });
+    }
   }
+  // We make everything absolute because relative path comparisons don't work for us.
+  entries.forEach(function(entry) {
+    // TODO support windows paths
+    entry.relativePath = path.join(entry.basePath, entry.relativePath);
+    entry.basePath = "/";
+  });
 
   var nextTree = new FSTree.fromEntries(entries, {sortAndExpand: true});
+  nextTree.addEntries(assetFiles, {sortAndExpand: true});
+
   var currentTree = this.currentTree;
   this.currentTree = nextTree;
   var patches = currentTree.calculatePatch(nextTree);
@@ -364,21 +413,20 @@ BroccoliSassCompiler.prototype.build = function() {
   this.events.on("compiled", function(details, result) {
     var depFiles = result.stats.includedFiles;
     for (var i = 0; i < depFiles.length; i++) {
-      self.dependencies[details.sassFilename] =
-        self.dependencies[details.sassFilename] || new Set();
-      self.dependencies[details.sassFilename].add(depFiles[i]);
+      self.addDependency(details.fullSassFilename, depFiles[i]);
     }
   });
 
   // TODO: handle indented syntax files.
   var treeFiles = removePathPrefix(inputPath, this.filesInTree(inputPath));
   treeFiles = treeFiles.filter(function(f, i) {
+    f = path.join(inputPath, f);
     if (self.dependencies[f] === undefined) {
       return true;
     }
     for (var p = 0; p < patches.length; p++) {
       var entry = patches[p][2];
-      if (self.dependencies[f].has(path.join(entry.basePath, entry.relativePath))) {
+      if (self.dependencies[f].has(entry.relativePath)) {
         return true;
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,15 @@ EyeglassCompiler.prototype.handleNewFile = function(details) {
   details.options.eyeglass.engines.sass = details.options.eyeglass.engines.sass || this.sass;
 
   var eyeglass = new Eyeglass(details.options);
+
+  // set up asset dependency tracking
+  var self = this;
+  var realResolve = eyeglass.assets.resolve;
+  eyeglass.assets.resolve = function(filepath, fullUri, cb) {
+    self.events.emit("dependency", filepath);
+    realResolve.call(eyeglass.assets, filepath, fullUri, cb);
+  };
+
   if (this.assetDirectories) {
     for (var i = 0; i < this.assetDirectories.length; i++) {
       eyeglass.assets.addSource(path.resolve(".", this.assetDirectories[i]), {


### PR DESCRIPTION
This change makes it so that changes to assets force recompilation of the sass files that use them. This is important for the situation where assets are removed but there are still references to them in the stylesheets (so that the build fails) or if the asset is inlined, etc.