### PR TITLE
Refactor dependency tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4.2"
   - "6"
   - "6.1"
   - "0.12.2"

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -10,6 +10,7 @@ var colors = require("colors/safe");
 var RSVP = require("rsvp");
 var EventEmitter = require("chained-emitter").EventEmitter;
 var FSTree = require("fs-tree-diff");
+var FSTreeFromEntries = FSTree.fromEntries;
 var walkSync = require("walk-sync");
 
 
@@ -405,7 +406,7 @@ function absolutizeEntries(entries) {
 BroccoliSassCompiler.prototype.knownDependenciesTree = function(inputPath) {
   var entries = walkSync.entries(inputPath);
   absolutizeEntries(entries);
-  var tree = new FSTree.fromEntries(entries);
+  var tree = new FSTreeFromEntries(entries);
   tree.addEntries(this.knownDependencies(), {sortAndExpand: true});
   return tree;
 };

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -216,7 +216,16 @@ function BroccoliSassCompiler(inputTree, options) {
     this.events.on("compiled", this.logCompilationSuccess.bind(this));
     this.events.on("failed", this.logCompilationFailure.bind(this));
   }
+
+  this.events.addListener("compiled", function(details, result) {
+    var depFiles = result.stats.includedFiles;
+    for (var i = 0; i < depFiles.length; i++) {
+      this.addDependency(details.fullSassFilename, depFiles[i]);
+    }
+  }.bind(this));
+
 }
+
 BroccoliSassCompiler.prototype = Object.create(BroccoliPlugin.prototype);
 BroccoliSassCompiler.prototype.constructor = BroccoliSassCompiler;
 BroccoliSassCompiler.prototype.logCompilationSuccess = function(details, result) {
@@ -432,15 +441,6 @@ BroccoliSassCompiler.prototype.build = function() {
   // console.log("Building Cache State took", timeSince(startTime));
 
 
-  // TODO: move this out of build?
-  var dependencyTracker = function(details, result) {
-    var depFiles = result.stats.includedFiles;
-    for (var i = 0; i < depFiles.length; i++) {
-      self.addDependency(details.fullSassFilename, depFiles[i]);
-    }
-  };
-
-  this.events.addListener("compiled", dependencyTracker);
 
   // TODO: handle indented syntax files.
   var treeFiles = removePathPrefix(inputPath, this.filesInTree(inputPath));
@@ -460,7 +460,6 @@ BroccoliSassCompiler.prototype.build = function() {
   this.clearDependencies();
 
   return RSVP.all(self.compileTree(inputPath, treeFiles, outputPath)).finally(function() {
-    self.events.removeListener("compiled", dependencyTracker);
     if (!self.currentTree) {
       self.currentTree = self.knownDependenciesTree(inputPath);
     }

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -187,7 +187,7 @@ function BroccoliSassCompiler(inputTree, options) {
   this.options = copyObject(options || {});
   this.events = new EventEmitter();
 
-  this.currentTree = new FSTree();
+  this.currentTree = null;
   this.dependencies = {};
 
   moveOption(this.options, this, "cssDir", "sassDir",
@@ -402,35 +402,6 @@ function absolutizeEntries(entries) {
   });
 }
 
-BroccoliSassCompiler.prototype.possibleDependenciesTree = function(inputPath) {
-  var entries = walkSync.entries(inputPath);
-  if (this.options.includePaths) {
-    this.options.includePaths.forEach(function(p) {
-      entries = entries.concat(walkSync.entries(p));
-    });
-  }
-  var eyeglass = new Eyeglass(this.options);
-  var moduleKeys = Object.keys(eyeglass.modules.collection);
-  var assetFiles = [];
-  for (var m = 0; m < moduleKeys.length; m++) {
-    var mod = eyeglass.modules.collection[moduleKeys[m]];
-    entries = entries.concat(walkSync.entries(mod.sassDir));
-    if (mod.assets) {
-      mod.assets.sources.forEach(function(source){
-        source.getAssets(mod.name).files.forEach(function(asset) {
-          assetFiles.push(new Entry(asset.sourcePath));
-        });
-      });
-    }
-  }
-
-  absolutizeEntries(entries);
-
-  var tree = new FSTree.fromEntries(entries, {sortAndExpand: true});
-  tree.addEntries(assetFiles, {sortAndExpand: true});
-  return tree;
-};
-
 BroccoliSassCompiler.prototype.knownDependenciesTree = function(inputPath) {
   var entries = walkSync.entries(inputPath);
   absolutizeEntries(entries);
@@ -442,29 +413,25 @@ BroccoliSassCompiler.prototype.knownDependenciesTree = function(inputPath) {
 
 
 BroccoliSassCompiler.prototype.build = function() {
+  var self = this;
+  var nextTree = null;
+  var patches = [];
   var inputPath = this.inputPaths[0];
   var outputPath = this.outputPath;
+  var currentTree = this.currentTree;
 
 
   // var startTime = process.hrtime();
 
-  var nextTree;
   if (this.hasKnownDependencies()) {
     nextTree = this.knownDependenciesTree(inputPath);
-  } else {
-    nextTree = this.possibleDependenciesTree(inputPath);
+    this.currentTree = nextTree;
+    currentTree = currentTree || new FSTree();
+    patches = currentTree.calculatePatch(nextTree);
   }
-
-
-  var currentTree = this.currentTree;
-  this.currentTree = nextTree;
-  // On the second pass this will show a bunch of deletes of things that aren't
-  // actually dependencies. We don't care about those.
-  var patches = currentTree.calculatePatch(nextTree);
 
   // console.log("Building Cache State took", timeSince(startTime));
 
-  var self = this;
 
   // TODO: move this out of build?
   var dependencyTracker = function(details, result) {
@@ -493,8 +460,11 @@ BroccoliSassCompiler.prototype.build = function() {
 
   this.clearDependencies();
 
-  return RSVP.all(self.compileTree(inputPath, treeFiles, outputPath)).then(function() {
+  return RSVP.all(self.compileTree(inputPath, treeFiles, outputPath)).finally(function() {
     self.events.removeListener("compiled", dependencyTracker);
+    if (!self.currentTree) {
+      self.currentTree = self.knownDependenciesTree(inputPath);
+    }
   });
 };
 

--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -2,17 +2,12 @@ var path = require("path");
 var fs = require("fs");
 var mkdirp = require("mkdirp");
 var BroccoliPlugin = require("broccoli-plugin");
-var MergeTrees = require("broccoli-merge-trees");
-var Eyeglass = require("eyeglass");
 var sass = require("node-sass");
 var glob = require("glob");
-var colors = require("colors/safe");
 var RSVP = require("rsvp");
-var EventEmitter = require("chained-emitter").EventEmitter;
 var FSTree = require("fs-tree-diff");
 var FSTreeFromEntries = FSTree.fromEntries;
 var walkSync = require("walk-sync");
-
 
 function unique(array) {
   var o = {};
@@ -175,6 +170,7 @@ function BroccoliSassCompiler(inputTree, options) {
                    "Passing the trees to broccoli-merge-trees with the overwrite option set,\n" +
                    "but you should do this yourself if you need to compile CSS files from them\n" +
                    "or use the node-sass includePaths option if you need to import from them.");
+      var MergeTrees = require("broccoli-merge-trees");
       inputTree = new MergeTrees(inputTree, {overwrite: true, annotation: "Sass Trees"});
     } else {
       inputTree = inputTree[0];
@@ -186,6 +182,7 @@ function BroccoliSassCompiler(inputTree, options) {
 
   this.sass = sass;
   this.options = copyObject(options || {});
+  var EventEmitter = require("chained-emitter").EventEmitter;
   this.events = new EventEmitter();
 
   this.currentTree = null;
@@ -215,6 +212,7 @@ function BroccoliSassCompiler(inputTree, options) {
   forbidNodeSassOption(this.options, "outFile");
 
   if (this.verbose) {
+    this.colors = require("colors/safe");
     this.events.on("compiled", this.logCompilationSuccess.bind(this));
     this.events.on("failed", this.logCompilationFailure.bind(this));
   }
@@ -226,15 +224,15 @@ BroccoliSassCompiler.prototype.logCompilationSuccess = function(details, result)
   if (timeInSeconds === 0) {
     timeInSeconds = "0.001"; // nothing takes zero seconds.
   }
-  var action = colors.inverse.green("compile (" + timeInSeconds + "s)");
+  var action = this.colors.inverse.green("compile (" + timeInSeconds + "s)");
   var message = details.fullSassFilename + " => " + details.cssFilename;
   console.log(action + " " + message);
 };
 
 BroccoliSassCompiler.prototype.logCompilationFailure = function(details, error) {
   var sassFilename = details.sassFilename;
-  var action = colors.bgRed.white("error");
-  var message = colors.red(error.message);
+  var action = this.colors.bgRed.white("error");
+  var message = this.colors.red(error.message);
   var location = "Line " + error.line + ", Column " + error.column;
   if (error.file.substring(error.file.length - sassFilename.length) !== sassFilename) {
     location = location + " of " + error.file;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var BroccoliSassCompiler = require("./broccoli_sass_compiler");
-var Eyeglass = require("eyeglass");
 var path = require("path");
 
 function httpJoin() {
@@ -20,6 +19,7 @@ function httpJoin() {
 }
 
 function EyeglassCompiler(inputTrees, options) {
+  this.Eyeglass = require("eyeglass");
   if (!Array.isArray(inputTrees)) {
     inputTrees = [inputTrees];
   }
@@ -70,7 +70,7 @@ EyeglassCompiler.prototype.handleNewFile = function(details) {
   details.options.eyeglass.engines = details.options.eyeglass.engines || {};
   details.options.eyeglass.engines.sass = details.options.eyeglass.engines.sass || this.sass;
 
-  var eyeglass = new Eyeglass(details.options);
+  var eyeglass = new this.Eyeglass(details.options);
 
   // set up asset dependency tracking
   var self = this;


### PR DESCRIPTION
Did a code review with @stefanpenner and these changes fell out of that.

Turns out the optimistic guess at the dependency tree wasn't needed -- instead we take a snapshot at the end of the first compile run.