### PR TITLE
remove stray it.only from tests

### DIFF
--- a/test/test_eyeglass_plugin.js
+++ b/test/test_eyeglass_plugin.js
@@ -1011,7 +1011,7 @@ describe("EyeglassCompiler", function () {
         });
     });
 
-    it.only("invalidates when eyeglass modules javascript files changes (package.json).", function() {
+    it("invalidates when eyeglass modules javascript files changes (package.json).", function() {
       var projectDir = makeFixtures("projectDir.tmp", {
         "project.scss":
           ".foo { content: foo(); }\n"


### PR DESCRIPTION
This makes the rest of the test suite also run.

I don't know if this was intentionally left in there but I ran into it while trying to debug an issue in my ember app.
