### PR TITLE
Ensure dependency and additional-output events are remove both when s…

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -679,11 +679,12 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
         this.events.addListener("additional-output", additionalOutputListener);
         this.events.addListener("dependency", dependencyListener);
 
-        return sass(details.options)
-          .then(result => {
+        return Promise.resolve(sass(details.options))
+          .finally(() => {
             this.events.removeListener("dependency", dependencyListener);
             this.events.removeListener("additional-output", additionalOutputListener);
-
+          })
+          .then(result => {
             return success(result).then(() => result);
           }, failure);
       });


### PR DESCRIPTION
…ass compilation is successful and when it fails.

Previously we would not cleanup these event handlers if the sass build failed.