### PR TITLE
[BUGFIX] don’t loose original stack-trace + error

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -699,11 +699,12 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
 
   handleFailure(details, error) {
     let failed = this.events.emit("failed", details, error);
-    let rethrow = failed.finally(() => {
-      let message = error.message;
-      let location = "    at " + error.file + ":" + error.line + ":" + error.column;
-      // TODO: implement fullException
-      throw new Error(message + "\n" + location);
+    let rethrow = failed.then(() => {
+      if (typeof error === "object" && error !== null) {
+        error.message = error.message  +
+          "\n    at " + error.file + ":" + error.line + ":" + error.column;
+      }
+      throw error;
     });
 
     return rethrow;


### PR DESCRIPTION
Rather then replacing the entire message, we now append file + line + column information to the existing error.message. That way we preserve important information (like stack) on the error.