### PR TITLE
fix race condition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,17 +94,21 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
     let realResolve = eyeglass.assets.resolve;
 
     eyeglass.assets.resolve = function(filepath, fullUri, cb) {
-      self.events.emit("dependency", filepath);
-      realResolve.call(eyeglass.assets, filepath, fullUri, cb);
+      self.events.emit("dependency", filepath).then(() => {
+        realResolve.call(eyeglass.assets, filepath, fullUri, cb);
+      }, cb);
     };
 
     let realInstall = eyeglass.assets.install;
     eyeglass.assets.install = function(file, uri, cb) {
       realInstall.call(eyeglass.assets, file, uri, (error, file) => {
-        if (!error) {
-          self.events.emit("additional-output", file);
+        if (error) {
+          cb (error, file);
+        } else {
+          self.events.emit("additional-output", file).then(() => {
+            cb(null, file);
+          }, cb);
         }
-        cb(error, file);
       });
     };
 


### PR DESCRIPTION
Wait until event emitter is drained before exiting, this ensures:

* progress is not made unless all current started operations complete:
* if errors occur, in the event emitter callbacks they are propagated correctly and causality is preserved.