### PR TITLE
Revert "Revert "[BUGFIX] ensure outputPath contains only symlinks""

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -19,6 +19,7 @@ const FSTreeFromEntries = FSTree.fromEntries;
 const walkSync = require("walk-sync");
 const os = require("os");
 const queue = require("async-promise-queue");
+const ensureSymlink = require("ensure-symlink");
 
 function absolutizeEntries(entries) {
   // We make everything absolute because relative path comparisons don't work for us.
@@ -485,15 +486,18 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
     persistentCacheDebug("cached output files for %s are: %s",
       details.sassFilename, files.join(", "));
 
-    return files.map(f => {
-      let data = outputFiles[f];
-      let outputFile = path.join(details.destDir, f);
+    return files.map(file => {
+      let data = outputFiles[file];
+      let cachedFile = path.join(this.cachePath, file);
+      let outputFile = path.join(this.outputPath, file);
       // populate the output cache for rebuilds
       this.addOutput(details.fullSassFilename, outputFile);
 
+      mkdirp.sync(path.dirname(cachedFile));
+      fs.writeFileSync(cachedFile, new Buffer(data, "base64"));
 
       mkdirp.sync(path.dirname(outputFile));
-      fs.writeFileSync(outputFile, new Buffer(data, "base64"));
+      ensureSymlink(cachedFile, outputFile);
     });
   }
 
@@ -667,8 +671,14 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
   }
 
   handleSuccess(details, result) {
-    mkdirp.sync(path.dirname(details.fullCssFilename));
-    fs.writeFileSync(details.fullCssFilename, result.css);
+    let cachedFile = path.join(this.cachePath, details.sassFilename);
+    let outputFile = details.fullCssFilename;
+
+    mkdirp.sync(path.dirname(cachedFile));
+    fs.writeFileSync(cachedFile, result.css);
+
+    mkdirp.sync(path.dirname(outputFile));
+    ensureSymlink(cachedFile, outputFile);
 
     return this.events.emit("compiled", details, result);
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chained-emitter": "^0.1.2",
     "colors": "^1.0.3",
     "debug": "^2.2.0",
+    "ensure-symlink": "^1.0.2",
     "eyeglass": "^1.3.0",
     "fs-tree-diff": "^0.5.3",
     "glob": "^7.1.2",

--- a/test/test_eyeglass_plugin.js
+++ b/test/test_eyeglass_plugin.js
@@ -19,6 +19,15 @@ const RSVP = require("rsvp");
 const glob = require("glob");
 const EyeglassCompiler = require("../lib/index");
 const SyncDiskCache = require("sync-disk-cache");
+const walkSync = require("walk-sync");
+
+function allFilesAreSymlinks(root) {
+  walkSync(root, {directories: false}).forEach(filepath => {
+    fs.readlinkSync(root + "/" + filepath); // throws if the file is not a link
+  });
+
+  assert(true, "all files are symlinks");
+}
 
 function fixtureDir(name) {
   return path.resolve(__dirname, "fixtures", name);
@@ -769,6 +778,42 @@ describe("EyeglassCompiler", function () {
     }
 
     afterEach(cleanupTempDirs);
+    it("output files are symlinks", function() {
+      let projectDir = makeFixtures("projectDir", {
+        "project.scss": '@import "related";',
+        "_related.scss": "/* This is related to something. */"
+      });
+      let expectedOutputDir = makeFixtures("expectedOutputDir", {
+        "project.css": "/* This is related to something. */\n"
+      });
+
+      let compiledFiles = [];
+      let builders = warmBuilders(2, projectDir, {
+        cssDir: ".",
+        persistentCache: "test"
+      }, details => {
+        compiledFiles.push(details.fullSassFilename);
+      });
+
+      return build(builders[0])
+        .then(outputDir => {
+          assertEqualDirs(outputDir, expectedOutputDir);
+          assert.equal(1, compiledFiles.length);
+          compiledFiles.length = 0;
+
+          allFilesAreSymlinks(outputDir);
+
+          return build(builders[1])
+            .then(outputDir2 => {
+              assert.notEqual(outputDir, outputDir2);
+              assert.equal(compiledFiles.length, 0);
+              assertEqualDirs(outputDir2, expectedOutputDir);
+
+              allFilesAreSymlinks(outputDir2);
+            });
+        });
+    });
+
 
     it("preserves cache across builder instances", function() {
       let projectDir = makeFixtures("projectDir", {

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,10 @@ ensure-posix-path@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz#a65b3e42d0b71cfc585eb774f9943c8d9b91b0c2"
 
+ensure-symlink@^1.0.0, ensure-symlink@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ensure-symlink/-/ensure-symlink-1.0.2.tgz#58ebc26d15a9539b9e79d00aa9623f8fa65ff18d"
+
 entities@1.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
@@ -754,13 +758,14 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
-eyeglass@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.2.1.tgz#68c12a60b06e8358972abc36479e2a9f364e6ad7"
+eyeglass@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.3.0.tgz#bcf293c701ca731b7f6f8e727d8b2aadd016c676"
   dependencies:
     archy "^1.0.0"
     deasync "^0.1.4"
     debug "^2.2.0"
+    ensure-symlink "^1.0.0"
     fs-extra "^0.30.0"
     glob "^7.1.0"
     lodash.includes "^4.3.0"


### PR DESCRIPTION
This reverts commit 9ccff8153515533fd1498751147853fb1bd6265f.

We haven't been able to reproduce the issue that lead us to this revert, so we should likely unrevert.