### PR TITLE
[BUGFIX] ensure resolved css filename is used for both cached directo…

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -671,7 +671,7 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
   }
 
   handleSuccess(details, result) {
-    let cachedFile = path.join(this.cachePath, details.sassFilename);
+    let cachedFile = path.join(this.cachePath, details.cssFilename);
     let outputFile = details.fullCssFilename;
 
     mkdirp.sync(path.dirname(cachedFile));

--- a/test/fixtures/assetsProject/input/styles/_unused.scss
+++ b/test/fixtures/assetsProject/input/styles/_unused.scss
@@ -1,0 +1,1 @@
+// changed but still not used.

--- a/test/fixtures/assetsProject/input/styles/_used.scss
+++ b/test/fixtures/assetsProject/input/styles/_used.scss
@@ -1,0 +1,1 @@
+$used-variable: true;

--- a/test/fixtures/assetsProject/input/styles/foo.scss
+++ b/test/fixtures/assetsProject/input/styles/foo.scss
@@ -1,0 +1,3 @@
+.foo {
+  background: asset-url("/images/foo.png")
+}


### PR DESCRIPTION
…ry and the output directory symlink as some consumers may produce two different output css files from the same input.

Specifically, if someone invokes the following callback https://github.com/sass-eyeglass/broccoli-eyeglass/blob/d91cab323a63800238c770ddbb05d0079c4c453c/lib/broccoli_sass_compiler.js#L330-L342 multiple times per `compileSassFile` invocation, but with different `resolvedCssFileName` arguments. Sadness would previously occur. 

- [x] test