### PR TITLE
Cache code that is generated to import assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,8 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
     this.assetDirectories = assetDirectories;
     this.assetsHttpPrefix = assetsHttpPrefix;
     this.events.on("compiling", this.handleNewFile.bind(this));
-    this.assetImportCache = {};
+
+    this._assetImportCache = Object.create(null);
     this._assetImportCacheStats = {
       hits: 0,
       misses: 0,
@@ -88,6 +89,8 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
       details.options.eyeglass.assets.relativeTo =
         httpJoin(details.options.eyeglass.httpRoot || "/", path.dirname(details.cssFilename));
     }
+
+    details.options.assetsCache = this.cacheAssetImports.bind(this);
 
     details.options.eyeglass.buildDir = details.destDir;
     details.options.eyeglass.engines = details.options.eyeglass.engines || {};
@@ -118,14 +121,6 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
         }
       });
     };
-
-    // cache the Scss that is generated to register assets
-    // the main collection, for files that use `@import "assets"`
-    this.cacheAssetImports(eyeglass.assets.collection);
-    // module collections, for files that use `@import "module/assets"`
-    eyeglass.assets.moduleCollections.forEach(function(collection) {
-      self.cacheAssetImports(collection);
-    });
 
     if (this.assetDirectories) {
       for (var i = 0; i < this.assetDirectories.length; i++) {
@@ -194,20 +189,16 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
     return key + "+" + dependencies;
   }
 
-  cacheAssetImports(collection) {
-    let self = this;
-    let realAsAssetImport = collection.asAssetImport;
-    collection.asAssetImport = function(name) {
-      // if this has already been generated, return it from cache
-      var cacheKey = collection.cacheKey(name);
-      if (self.assetImportCache[cacheKey] !== undefined) {
-        assetImportCacheDebug("asAssetImport(%s): cache hit for key '%s'", name, cacheKey);
-        self._assetImportCacheStats.hits += 1;
-        return self.assetImportCache[cacheKey];
-      }
-      assetImportCacheDebug("asAssetImport(%s): cache miss for key '%s'", name, cacheKey);
-      self._assetImportCacheStats.misses += 1;
-      return self.assetImportCache[cacheKey] = realAsAssetImport.call(collection, name);
-    };
+  // Cache the asset import code that is generated in eyeglass
+  cacheAssetImports(key, getValue) {
+    // if this has already been generated, return it from cache
+    if (this._assetImportCache[key] !== undefined) {
+      assetImportCacheDebug("cache hit for key '%s'", key);
+      this._assetImportCacheStats.hits += 1;
+      return this._assetImportCache[key];
+    }
+    assetImportCacheDebug("cache miss for key '%s'", key);
+    this._assetImportCacheStats.misses += 1;
+    return this._assetImportCache[key] = getValue();
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ const debugGenerator = require("debug");
 const persistentCacheDebug = debugGenerator("broccoli-eyeglass:persistent-cache");
 const CURRENT_VERSION = require(path.join(__dirname, "..", "package.json")).version;
 
+let assetCache = {};
+
 function httpJoin() {
   let joined = [];
   for (let i = 0; i < arguments.length; i++) {
@@ -112,6 +114,23 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
         }
       });
     };
+
+    // set up caching generated scss for registering assets
+    let realAsAssetImport = eyeglass.assets.collection.asAssetImport;
+    eyeglass.assets.collection.asAssetImport = function(name) {
+      // if this has already been generated, return it from cache
+      var cacheKey = eyeglass.assets.collection.sources.reduce(function(cacheStr, source) {
+        return cacheStr + ":" + source.cacheKey(name);
+      }, "sources");
+      if (assetCache[cacheKey] !== undefined) {
+        return assetCache[cacheKey];
+      }
+
+      var generatedScss = realAsAssetImport.call(name);
+      assetCache[cacheKey] = generatedScss;
+      return generatedScss;
+    };
+
 
     if (this.assetDirectories) {
       for (var i = 0; i < this.assetDirectories.length; i++) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,8 @@ const sortby = require("lodash.sortby");
 const stringify = require("json-stable-stringify");
 const debugGenerator = require("debug");
 const persistentCacheDebug = debugGenerator("broccoli-eyeglass:persistent-cache");
+const assetImportCacheDebug = debugGenerator("broccoli-eyeglass:asset-import-cache");
 const CURRENT_VERSION = require(path.join(__dirname, "..", "package.json")).version;
-
-let assetCache = {};
 
 function httpJoin() {
   let joined = [];
@@ -67,6 +66,11 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
     this.assetDirectories = assetDirectories;
     this.assetsHttpPrefix = assetsHttpPrefix;
     this.events.on("compiling", this.handleNewFile.bind(this));
+    this.assetImportCache = {};
+    this._assetImportCacheStats = {
+      hits: 0,
+      misses: 0,
+    };
   }
 
   handleNewFile(details) {
@@ -115,22 +119,13 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
       });
     };
 
-    // set up caching generated scss for registering assets
-    let realAsAssetImport = eyeglass.assets.collection.asAssetImport;
-    eyeglass.assets.collection.asAssetImport = function(name) {
-      // if this has already been generated, return it from cache
-      var cacheKey = eyeglass.assets.collection.sources.reduce(function(cacheStr, source) {
-        return cacheStr + ":" + source.cacheKey(name);
-      }, "sources");
-      if (assetCache[cacheKey] !== undefined) {
-        return assetCache[cacheKey];
-      }
-
-      var generatedScss = realAsAssetImport.call(name);
-      assetCache[cacheKey] = generatedScss;
-      return generatedScss;
-    };
-
+    // cache the Scss that is generated to register assets
+    // the main collection, for files that use `@import "assets"`
+    this.cacheAssetImports(eyeglass.assets.collection);
+    // module collections, for files that use `@import "module/assets"`
+    eyeglass.assets.moduleCollections.forEach(function(collection) {
+      self.cacheAssetImports(collection);
+    });
 
     if (this.assetDirectories) {
       for (var i = 0; i < this.assetDirectories.length; i++) {
@@ -197,5 +192,22 @@ module.exports = class EyeglassCompiler extends BroccoliSassCompiler {
     let dependencies = this.dependenciesHash(srcDir, relativeFilename, options);
 
     return key + "+" + dependencies;
+  }
+
+  cacheAssetImports(collection) {
+    let self = this;
+    let realAsAssetImport = collection.asAssetImport;
+    collection.asAssetImport = function(name) {
+      // if this has already been generated, return it from cache
+      var cacheKey = collection.cacheKey(name);
+      if (self.assetImportCache[cacheKey] !== undefined) {
+        assetImportCacheDebug("asAssetImport(%s): cache hit for key '%s'", name, cacheKey);
+        self._assetImportCacheStats.hits += 1;
+        return self.assetImportCache[cacheKey];
+      }
+      assetImportCacheDebug("asAssetImport(%s): cache miss for key '%s'", name, cacheKey);
+      self._assetImportCacheStats.misses += 1;
+      return self.assetImportCache[cacheKey] = realAsAssetImport.call(collection, name);
+    };
   }
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "colors": "^1.0.3",
     "debug": "^2.2.0",
     "ensure-symlink": "^1.0.2",
-    "eyeglass": "^1.4.0",
+    "eyeglass": "^1.4.1",
     "fs-tree-diff": "^0.5.3",
     "glob": "^7.1.2",
     "hash-for-dep": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "colors": "^1.0.3",
     "debug": "^2.2.0",
     "ensure-symlink": "^1.0.2",
-    "eyeglass": "^1.3.0",
+    "eyeglass": "^1.4.0",
     "fs-tree-diff": "^0.5.3",
     "glob": "^7.1.2",
     "hash-for-dep": "^1.2.0",

--- a/test/test_eyeglass_plugin.js
+++ b/test/test_eyeglass_plugin.js
@@ -1205,14 +1205,14 @@ describe("EyeglassCompiler", function () {
       let builder = new broccoli.Builder(compiler);
 
       // cache should start empty
-      assert.deepEqual(compiler.assetImportCache, {});
+      assert.deepEqual(compiler._assetImportCache, {});
 
       return build(builder)
         .then(outputDir => {
           assertEqualDirs(outputDir, expectedOutputDir);
           // cache should have one entry
-          assert.notDeepEqual(compiler.assetImportCache, {});
-          assert.equal(Object.keys(compiler.assetImportCache).length, 1);
+          assert.notDeepEqual(compiler._assetImportCache, {});
+          assert.equal(Object.keys(compiler._assetImportCache).length, 1);
           // first file should be a miss, 2nd should return from cache
           assert.equal(compiler._assetImportCacheStats.misses, 1);
           assert.equal(compiler._assetImportCacheStats.hits, 1);
@@ -1260,14 +1260,14 @@ describe("EyeglassCompiler", function () {
       let builder = new broccoli.Builder(compiler);
 
       // cache should start empty
-      assert.deepEqual(compiler.assetImportCache, {});
+      assert.deepEqual(compiler._assetImportCache, {});
 
       return build(builder)
         .then(outputDir => {
           assertEqualDirs(outputDir, expectedOutputDir);
           // cache should have one entry
-          assert.notDeepEqual(compiler.assetImportCache, {});
-          assert.equal(Object.keys(compiler.assetImportCache).length, 1);
+          assert.notDeepEqual(compiler._assetImportCache, {});
+          assert.equal(Object.keys(compiler._assetImportCache).length, 1);
           // first file should be a miss, 2nd should return from cache
           assert.equal(compiler._assetImportCacheStats.misses, 1);
           assert.equal(compiler._assetImportCacheStats.hits, 1);

--- a/test/test_eyeglass_plugin.js
+++ b/test/test_eyeglass_plugin.js
@@ -1189,6 +1189,91 @@ describe("EyeglassCompiler", function () {
         });
     });
 
+    it("caches main asset import scss", function() {
+      let projectDir = makeFixtures("projectDir", {
+        "file1.scss": '@import "assets";\n',
+        "file2.scss": '@import "assets";\n',
+      });
+      let expectedOutputDir = makeFixtures("expectedOutputDir", {
+        "file1.css": "",
+        "file2.css": "",
+      });
+
+      let compiler = new EyeglassCompiler(projectDir, {
+        cssDir: ".",
+      });
+      let builder = new broccoli.Builder(compiler);
+
+      // cache should start empty
+      assert.deepEqual(compiler.assetImportCache, {});
+
+      return build(builder)
+        .then(outputDir => {
+          assertEqualDirs(outputDir, expectedOutputDir);
+          // cache should have one entry
+          assert.notDeepEqual(compiler.assetImportCache, {});
+          assert.equal(Object.keys(compiler.assetImportCache).length, 1);
+          // first file should be a miss, 2nd should return from cache
+          assert.equal(compiler._assetImportCacheStats.misses, 1);
+          assert.equal(compiler._assetImportCacheStats.hits, 1);
+        });
+    });
+
+    it("caches module asset import scss", function() {
+      let projectDir = makeFixtures("projectDir", {
+        "file1.scss": '@import "eyeglass-module/assets";\n',
+        "file2.scss": '@import "eyeglass-module/assets";\n',
+      });
+      let eyeglassModDir = makeFixtures("eyeglassmod", {
+        "package.json": "{\n" +
+                        '  "name": "is_a_module",\n' +
+                        '  "keywords": ["eyeglass-module"],\n' +
+                        '  "main": "eyeglass-exports.js",\n' +
+                        '  "private": true,\n' +
+                        '  "eyeglass": {\n' +
+                        '    "name": "eyeglass-module",\n' +
+                        '    "needs": "*"\n' +
+                        "  }\n" +
+                        "}",
+        "eyeglass-exports.js":
+          'var path = require("path");\n' +
+          "module.exports = function(eyeglass, sass) {\n" +
+          "  return {\n" +
+          "    sassDir: __dirname, // directory where the sass files are.\n" +
+          '    assets: eyeglass.assets.export(path.join(__dirname, "images"))\n' +
+          "  };\n" +
+          "};",
+      });
+      let expectedOutputDir = makeFixtures("expectedOutputDir", {
+        "file1.css": "",
+        "file2.css": ""
+      });
+
+      let compiler = new EyeglassCompiler(projectDir, {
+        cssDir: ".",
+        eyeglass: {
+          modules: [
+            {path: eyeglassModDir}
+          ]
+        }
+      });
+      let builder = new broccoli.Builder(compiler);
+
+      // cache should start empty
+      assert.deepEqual(compiler.assetImportCache, {});
+
+      return build(builder)
+        .then(outputDir => {
+          assertEqualDirs(outputDir, expectedOutputDir);
+          // cache should have one entry
+          assert.notDeepEqual(compiler.assetImportCache, {});
+          assert.equal(Object.keys(compiler.assetImportCache).length, 1);
+          // first file should be a miss, 2nd should return from cache
+          assert.equal(compiler._assetImportCacheStats.misses, 1);
+          assert.equal(compiler._assetImportCacheStats.hits, 1);
+        });
+    });
+
     it("can force invalidate the persistent cache", function() {
       let projectDir = makeFixtures("projectDir", {
         "project.scss": '@import "related";',

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,9 +758,9 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
-eyeglass@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.3.0.tgz#bcf293c701ca731b7f6f8e727d8b2aadd016c676"
+eyeglass@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.4.0.tgz#3d36b67257b60e56a7eabd276840891caf06def5"
   dependencies:
     archy "^1.0.0"
     deasync "^0.1.4"
@@ -768,6 +768,7 @@ eyeglass@^1.3.0:
     ensure-symlink "^1.0.0"
     fs-extra "^0.30.0"
     glob "^7.1.0"
+    json-stable-stringify "^1.0.1"
     lodash.includes "^4.3.0"
     lodash.merge "^4.6.0"
     node-sass "^4.0.0 || ^3.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,9 +758,9 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
-eyeglass@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.4.0.tgz#3d36b67257b60e56a7eabd276840891caf06def5"
+eyeglass@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/eyeglass/-/eyeglass-1.4.1.tgz#641591720df59291690cea7c45afa64d04840838"
   dependencies:
     archy "^1.0.0"
     deasync "^0.1.4"


### PR DESCRIPTION
## Problem

When compiling a sass file, eyeglass generates code to register the assets for that file. So in the sass file it can use `@import "assets"` or `@import "module/assets"` to register assets with eyeglass. When compiling multiple files, the same code is generated for every file, over and over again.

## Solution

Do it once, cache the result, and return that.

I have added functions to generate cache keys for sources and collections in eyeglass: https://github.com/sass-eyeglass/eyeglass/pull/179. This uses those cache keys to cache the scss that is generated for registering assets, so it is only done once for each asset collection.