### PR TITLE
lazy require node-sass

### DIFF
--- a/lib/broccoli_sass_compiler.js
+++ b/lib/broccoli_sass_compiler.js
@@ -12,7 +12,6 @@ const Promise = RSVP.Promise;
 const mkdirp = require("mkdirp");
 mkdirp.promise = mkdirp.promise || RSVP.denodeify(mkdirp);
 const BroccoliPlugin = require("broccoli-plugin");
-const sass = require("node-sass");
 const glob = require("glob");
 const FSTree = require("fs-tree-diff");
 const FSTreeFromEntries = FSTree.fromEntries;
@@ -20,6 +19,17 @@ const walkSync = require("walk-sync");
 const os = require("os");
 const queue = require("async-promise-queue");
 const ensureSymlink = require("ensure-symlink");
+
+let sass;
+let renderSass;
+
+function initSass() {
+  if (!sass) {
+    sass = require("node-sass");
+    // Standard async rendering for node-sass.
+    renderSass = RSVP.denodeify(sass.render);
+  }
+}
 
 function absolutizeEntries(entries) {
   // We make everything absolute because relative path comparisons don't work for us.
@@ -70,9 +80,6 @@ function unique(array) {
   }
   return rv;
 }
-
-// Standard async rendering for node-sass.
-const renderSass = RSVP.denodeify(sass.render);
 
 // This promise runs sass synchronously
 function renderSassSync(options) {
@@ -369,6 +376,7 @@ module.exports = class BroccoliSassCompiler extends BroccoliPlugin {
   }
 
   renderer() {
+    initSass();
     if (this.renderSync) {
       return renderSassSync;
     } else {


### PR DESCRIPTION
This ensures that we only `require('node-sass')` if/when we invoke the `renderer`