### PR TITLE
Update license to valid SPDX license code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.4.1",
   "author": "Chris Eppstein <chris@eppsteins.net>",
   "main": "lib/index.js",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/sass-eyeglass/broccoli-eyeglass"


### PR DESCRIPTION
This isn't an actual license change, just fixing things up to avoid a warning from `yarn`:

```
warning broccoli-eyeglass@4.4.1: License should be a valid SPDX license expression
```

For reference, here is the SPDX list: https://spdx.org/licenses/